### PR TITLE
register required promise for ApplyTilingSpec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ add_llvm_executable(tutorial-compiler
     DEPENDS
 
     TutorialPassIncGen
-    MLIRTutorialIncGen
 )
 
 llvm_update_compile_flags(tutorial-compiler)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.28)
 
 project(tutorial-compiler LANGUAGES CXX C)
 

--- a/example.mlir
+++ b/example.mlir
@@ -16,7 +16,7 @@ module attributes { transform.with_named_sequence } {
       %filter: !tfilter,
       %bias: !tbias,
       %output: !toutput)  -> !toutput
-    attributes { }
+//    attributes { transform_tiling_spec = "__halide" }
   {
     %bias_init = tensor.empty() : !toutput
     %biased = linalg.broadcast ins(%bias : !tbias)

--- a/main.cpp
+++ b/main.cpp
@@ -166,6 +166,7 @@ LogicalResult tutorialOpt(int argc, char **argv) {
       registry);
   vector::registerSubsetOpInterfaceExternalModels(registry);
   scf::registerBufferDeallocationOpInterfaceExternalModels(registry);
+  affine::registerValueBoundsOpInterfaceExternalModels(registry);
 
   tensor::registerTransformDialectExtension(registry);
   scf::registerTransformDialectExtension(registry);


### PR DESCRIPTION
This PR makes three changes:
- rolls back required CMake version to the newest provided by Ubuntu 24.04 which does not cause any differences in CMake behavior
- fixes the `ApplyTilingSpec` pass by registering a required external model promise, specifically the `ValueBoundsOpInterface`
- adds the commented out `transform_tiling_spec` per the comment in the `example.mlir`